### PR TITLE
[ColumnHiding] fix error in js code: do not look up undefined in array

### DIFF
--- a/src/Resources/public/cubecommon.js
+++ b/src/Resources/public/cubecommon.js
@@ -18,7 +18,7 @@ if (typeof(cubetools) === 'undefined') {
         var cols = table.find('td, th, col');
         cols.each(function () {
             var colId = $(this).attr('id');
-            if (hidableSettings[colId]) {
+            if (colId && hidableSettings[colId]) {
                 cs.updateOneCol(colId, hidableSettings[colId].hidden);
             }
         });


### PR DESCRIPTION
Looking up `anArray[variableWithValueUndefined]` triggers an error at least in mozilla.
Did never metion before. Maybe null was returned by attr(), maybe the case never happened, ...