### PR TITLE
[CollectionHandler:processValue] avoid toString on DateTime object #131

### DIFF
--- a/src/DataHandling/CollectionHandler.php
+++ b/src/DataHandling/CollectionHandler.php
@@ -138,8 +138,10 @@ class CollectionHandler
     {
         if ($rawElement) {
             $columnOutputValue = $this->rawElementProcessor->{$this->rawElementProcessorMethodName}((string) $columnValue);
-        } else {
+        } else if (is_scalar($columnValue) || (is_object($columnValue) && method_exists($columnValue, '__toString'))) {
             $columnOutputValue = (string) $columnValue;
+        } else {
+            $columnOutputValue = $columnValue;
         }
 
         return $columnOutputValue;


### PR DESCRIPTION
DateTime object can be send to Excel (when it was send as string, it was treated in Excel like normal text field).