### PR TITLE
[Symfony] handling dnString parameter to be compatible with SF4 #60

### DIFF
--- a/src/Security/VersatileLdapBindAuthenticationProvider.php
+++ b/src/Security/VersatileLdapBindAuthenticationProvider.php
@@ -19,9 +19,7 @@ use Symfony\Component\Ldap\Exception\ConnectionException;
  */
 class VersatileLdapBindAuthenticationProvider extends LdapBindAuthenticationProvider
 {
-    const DEFAULT_DN_STRING = '{username}';
-
-    public function __construct(UserProviderInterface $userProvider, UserCheckerInterface $userChecker, $providerKey, LdapInterface $ldap, $dnString = self::DEFAULT_DN_STRING, $hideUserNotFoundExceptions = true)
+    public function __construct(UserProviderInterface $userProvider, UserCheckerInterface $userChecker, string $providerKey, LdapInterface $ldap, string $dnString = '{username}', bool $hideUserNotFoundExceptions = true, string $searchDn = '', string $searchPassword = '')
     {
         try {
             // ldap must be bound to allow anonymous search queries
@@ -30,12 +28,7 @@ class VersatileLdapBindAuthenticationProvider extends LdapBindAuthenticationProv
             // hide exception
         }
 
-        if (is_null($dnString)) {
-            // null value causes Symfony exception
-            $dnString = self::DEFAULT_DN_STRING;
-        }
-
-        parent::__construct($userProvider, $userChecker, $providerKey, $ldap, $dnString, $hideUserNotFoundExceptions);
+        parent::__construct($userProvider, $userChecker, $providerKey, $ldap, $dnString, $hideUserNotFoundExceptions, $searchDn, $searchPassword);
     }
 
     /**

--- a/src/Security/VersatileLdapBindAuthenticationProvider.php
+++ b/src/Security/VersatileLdapBindAuthenticationProvider.php
@@ -19,13 +19,20 @@ use Symfony\Component\Ldap\Exception\ConnectionException;
  */
 class VersatileLdapBindAuthenticationProvider extends LdapBindAuthenticationProvider
 {
-    public function __construct(UserProviderInterface $userProvider, UserCheckerInterface $userChecker, $providerKey, LdapInterface $ldap, $dnString = '{username}', $hideUserNotFoundExceptions = true)
+    const DEFAULT_DN_STRING = '{username}';
+
+    public function __construct(UserProviderInterface $userProvider, UserCheckerInterface $userChecker, $providerKey, LdapInterface $ldap, $dnString = self::DEFAULT_DN_STRING, $hideUserNotFoundExceptions = true)
     {
         try {
             // ldap must be bound to allow anonymous search queries
             $ldap->bind();
         } catch (ConnectionException $e) {
             // hide exception
+        }
+
+        if (is_null($dnString)) {
+            // null value causes Symfony exception
+            $dnString = self::DEFAULT_DN_STRING;
         }
 
         parent::__construct($userProvider, $userChecker, $providerKey, $ldap, $dnString, $hideUserNotFoundExceptions);


### PR DESCRIPTION
Fix for error in SF4:
Argument 5 passed to Symfony\Component\Security\Core\Authentication\Provider\LdapBindAuthenticationProvider::__construct() must be of the type string, null given, called in /var/www/cubepa/pa/vendor/cubetools/cube-common-bundle/src/Security/VersatileLdapBindAuthenticationProvider.php